### PR TITLE
rank FC 수정

### DIFF
--- a/app/src/main/java/com/eee/www/nugasa/model/FingerMap.kt
+++ b/app/src/main/java/com/eee/www/nugasa/model/FingerMap.kt
@@ -80,7 +80,8 @@ class FingerMap {
         val tempList = shuffleList()
         val rankMap = mutableMapOf<Int, Int>()
         _map.forEach {
-            rankMap[it.key] = tempList[it.key] + 1 // +1 is for except 0
+            // +1 is for remove 0
+            rankMap[it.key] = tempList.indexOf(it.key) + 1
         }
         return rankMap
     }


### PR DESCRIPTION
5개의 터치가 있었을 때 key가 순차적으로 {0,1,2,3,4} 인 경우가 대부분이었지만
마구 뗐다붙였다 한 경우에
터치가 2개인데 {3,6} 이렇게 key가 되는 경우가 있었다.
이런 경우에 indexOutofBounds 에러가 나서
순서로 넣어주도록 수정했다.