### PR TITLE
signing.properties 파일 생성해서 앞으로 release sign 유지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# signing setting file
+signing.properties

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ local.properties
 
 # signing setting file
 signing.properties
+*.jks

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,11 +18,12 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
+    signingConfigs { release }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
     compileOptions {
@@ -51,4 +52,26 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+}
+
+loadSigningConfigs()
+
+def loadSigningConfigs() {
+    File propFile = file('../signing.properties')
+    if (propFile.exists()) {
+        def props = new Properties()
+        props.load(new FileInputStream(propFile))
+
+        if (props.containsKey('STORE_FILE') && props.containsKey('STORE_PASSWORD') &&
+                props.containsKey('KEY_ALIAS') && props.containsKey('KEY_PASSWORD')) {
+            android.signingConfigs.release.storeFile = file(props['STORE_FILE'])
+            android.signingConfigs.release.storePassword = props['STORE_PASSWORD']
+            android.signingConfigs.release.keyAlias = props['KEY_ALIAS']
+            android.signingConfigs.release.keyPassword = props['KEY_PASSWORD']
+        } else {
+            android.buildTypes.release.signingConfig = null
+        }
+    } else {
+        android.buildTypes.release.signingConfig = null
+    }
 }


### PR DESCRIPTION
## 수정사항
- jks 파일 루트 프로젝트에 넣어도 git ignore
- gitignore된 signing.properties 파일을 통해서 signing config 정보들 받아와서 설정 [참고한 코드](https://gist.github.com/SleeplessByte/89c90f702c0f2fdc2b12)

## 수정사항 적용 후!
- jks 파일 루트 프로젝트에 편하게 넣어두기
- signing.properties 파일 받은거 루트 프로젝트에 넣어두기

앞으로 또 업데이트할 일이 있으면 잘 사용할 것 같습니다><